### PR TITLE
Convenient constructors for `CompositeModel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCModels"
 uuid = "c814dc9f-a51f-4eaf-877f-82eda4edad48"
+version = "1.0.3"
 authors = ["James Gardner <james.gardner1421@gmail.com>"]
-version = "1.0.2"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
@@ -33,6 +33,7 @@ DelimitedFiles = "1.9.1"
 FastGaussQuadrature = "0.4, 0.5, 1"
 FiniteDiff = "2.27.0"
 ForwardDiff = "0.10"
+JuLIP = "0.13, 0.14, 0.15, 0.16"
 NQCBase = "1.0"
 Parameters = "0.12"
 PythonCall = "0.9.24"

--- a/src/subsystems.jl
+++ b/src/subsystems.jl
@@ -66,6 +66,20 @@ Any calls made to `potential`, `derivative` and `friction` will apply each subsy
 Some checks are made to ensure each atom is affected by a model and that each model is applied over the same degrees of freedom, but no other sanity checks are made. 
 """
 CompositeModel(subsystems::Subsystem...) = CompositeModel(check_models(subsystems...)...) # Check subsystems are a valid combination
+# Convenience version which uses Models and automatically applies across all indices. 
+CompositeModel(models::Model...) = CompositeModel(Subsystem.(models, Colon())...)
+# Mixed use version with Models and Subsystems. 
+function CompositeModel(model_or_subsystems::Union{Model, FrictionModels.ElectronicFrictionProvider, Subsystem}...)
+	subsystems = Subsystem[]
+	for model_or_subsystem in model_or_subsystems
+		if !isa(model_or_subsystem, Subsystem)
+			push!(subsystems, Subsystem(model_or_subsystem, Colon()))
+		else
+			push!(subsystems, model_or_subsystem)
+		end
+	end
+	return CompositeModel(subsystems...)
+end
 
 get_friction_models(system::Vector{<:Subsystem}) = @view system[findall(x->isa(x.model, FrictionModels.ElectronicFrictionProvider), system)]
 get_friction_models(system::CompositeModel) = get_friction_models(system.subsystems)


### PR DESCRIPTION
This PR makes `CompositeModel`s accept any combination of model types or `Subsystem`s as arguments and will construct an appropriate `CompositeModel` from them. 

Any model that is passed in will automatically apply to the entire atomic system. 